### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/pkg/analyzer/lib/src/generated/error_verifier.dart
+++ b/pkg/analyzer/lib/src/generated/error_verifier.dart
@@ -4121,7 +4121,7 @@ class ErrorVerifier extends RecursiveAstVisitor<Object> {
     InterfaceType mixinSupertype = mixinElement.supertype;
     if (mixinSupertype != null) {
       if (!mixinSupertype.isObject ||
-          !mixinElement.isMixinApplication && mixinElement.mixins.length != 0) {
+          !mixinElement.isMixinApplication && mixinElement.mixins.isNotEmpty) {
         _errorReporter.reportErrorForNode(
             CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT,
             mixinName,

--- a/pkg/analyzer/tool/summary/generate.dart
+++ b/pkg/analyzer/tool/summary/generate.dart
@@ -232,7 +232,7 @@ class _CodeGenerator {
                     'Class `$clsName`: TopLevel argument must be a string'
                     ' literal');
               }
-            } else if (annotation.arguments.length != 0) {
+            } else if (annotation.arguments.isNotEmpty) {
               throw new Exception(
                   'Class `$clsName`: TopLevel requires 0 or 1 arguments');
             }


### PR DESCRIPTION
Use isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)